### PR TITLE
add in-memory cache in front of articles repository

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// Config holds config settings parsed from the environment
+type Config struct {
+	CacheTTLSeconds int
+	DatabaseURL     string
+	Port            string
+}
+
+// New returns an initialized Config
+func New() Config {
+	dbURL := fromEnv("DATABASE_URL",
+		"postgresql://localhost:5432/dbmaj7?sslmode=disable")
+
+	cacheTTL, _ := strconv.Atoi(fromEnv("CACHE_TTL_SECONDS", "60"))
+
+	return Config{
+		CacheTTLSeconds: cacheTTL,
+		DatabaseURL:     dbURL,
+		Port:            fromEnv("PORT", "8080"),
+	}
+}
+
+// String is a prettier version of %+v for the Config struct
+func (c Config) String() string {
+	return fmt.Sprintf("Cache TTL: %ds\nDatabase URL: %s\nPort: %s\n\n",
+		c.CacheTTLSeconds, c.DatabaseURL, c.Port)
+}
+
+func fromEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	os.Setenv("CACHE_TTL_SECONDS", "123")
+	os.Setenv("DATABASE_URL", "postgres://tacos:pizza")
+
+	cfg := New()
+
+	if cfg.CacheTTLSeconds != 123 {
+		t.Errorf("expected ttl to be 123, got %d", cfg.CacheTTLSeconds)
+	}
+	if cfg.DatabaseURL != "postgres://tacos:pizza" {
+		t.Errorf("expected db url to be postgres://tacos:pizza, got %s", cfg.DatabaseURL)
+	}
+}

--- a/dbmaj7.go
+++ b/dbmaj7.go
@@ -4,23 +4,17 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 
 	"github.com/aczerepinski/dbmaj7/api"
+	"github.com/aczerepinski/dbmaj7/config"
 	"github.com/aczerepinski/dbmaj7/repository"
 )
 
 func main() {
-	fmt.Println("parsing environment variables")
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		databaseURL = "postgresql://localhost:5432/dbmaj7?sslmode=disable"
-	}
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
-	repo, err := repository.New(databaseURL)
+	appConfig := config.New()
+	fmt.Printf("application configuration initialized:\n%s", appConfig)
+
+	repo, err := repository.New(appConfig.DatabaseURL, appConfig.CacheTTLSeconds)
 	if err != nil {
 		log.Fatal("could not initialize database", err)
 	}
@@ -31,8 +25,7 @@ func main() {
 	http.HandleFunc("/api/articles", apiController.ArticleIndex)
 	http.HandleFunc("/static/", staticHandler)
 	http.HandleFunc("/", indexHandler)
-	fmt.Printf("initializing server on port %v", port)
-	http.ListenAndServe(":"+port, nil)
+	http.ListenAndServe(":"+appConfig.Port, nil)
 }
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {

--- a/repository/cache.go
+++ b/repository/cache.go
@@ -1,0 +1,72 @@
+package repository
+
+import (
+	"github.com/aczerepinski/dbmaj7/domain"
+	"sync"
+	"time"
+)
+
+const nanoMultiplier = 1000000000
+
+type cache struct {
+	ttl      int64
+	cleanInterval time.Duration
+	mu       sync.RWMutex
+	articles map[string]cacheArticle
+}
+
+type cacheArticle struct {
+	article    domain.Article
+	expiration int64
+}
+
+func newCache(ttlSeconds int) *cache {
+	c := &cache{
+		ttl:      int64(ttlSeconds) * nanoMultiplier,
+		articles: map[string]cacheArticle{},
+		cleanInterval: 10 * time.Second,
+	}
+
+	go c.startCleaning()
+	return c
+}
+
+func (c *cache) getArticleBySlug(slug string) (*domain.Article, error) {
+	c.mu.RLock()
+	a, ok := c.articles[slug]
+	c.mu.RUnlock()
+	if !ok {
+		return &domain.Article{}, ErrNotFound
+	}
+	return &a.article, nil
+}
+
+func (c *cache) saveArticle(a domain.Article) {
+	c.mu.Lock()
+	expiration := time.Now().UnixNano() + c.ttl
+	ca := cacheArticle{
+		article:    a,
+		expiration: expiration,
+	}
+	c.articles[a.Slug] = ca
+	c.mu.Unlock()
+}
+
+func (c *cache) startCleaning() {
+	t := time.NewTicker(c.cleanInterval)
+	for {
+		<-t.C
+		c.clean()
+	}
+}
+
+func (c *cache) clean() {
+	now := time.Now().UnixNano()
+	c.mu.Lock()
+	for k, v := range c.articles {
+		if v.expiration < now {
+			delete(c.articles, k)
+		}
+	}
+	c.mu.Unlock()
+}

--- a/repository/cache_test.go
+++ b/repository/cache_test.go
@@ -1,0 +1,99 @@
+package repository
+
+import (
+	"github.com/aczerepinski/dbmaj7/domain"
+	"testing"
+	"time"
+)
+
+const testSlug = "coltrane-is-the-best"
+
+func TestGetArticleBySlug(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		slug        string
+		expectedErr error
+	}{
+		{testSlug, nil},
+		{"go-testing-best-practices", ErrNotFound},
+	}
+
+	halfSecond := int64(500000000)
+	c := newTestCache(halfSecond)
+
+	for i, test := range tests {
+		if _, err := c.getArticleBySlug(test.slug); err != test.expectedErr {
+			t.Errorf("test %d: expected error to be %v, got %v",
+				i, test.expectedErr, err)
+		}
+	}
+}
+
+func TestSaveArticle(t *testing.T) {
+	t.Parallel()
+
+	halfSecond := int64(500000000)
+	c := newTestCache(halfSecond)
+	article := domain.Article{Slug: "a-love-supreme"}
+	c.saveArticle(article)
+
+	a, err := c.getArticleBySlug("a-love-supreme")
+	if err != nil {
+		t.Fatalf("expected err to be nil, got %v", err)
+	}
+	if a.Slug != "a-love-supreme" {
+		t.Errorf("expected slug to be a-love-supreme, got %s", a.Slug)
+	}
+}
+
+func TestClean(t *testing.T) {
+	t.Parallel()
+
+	oneNanoSecond := int64(1)
+	c := newTestCache(oneNanoSecond)
+
+	if _, err := c.getArticleBySlug(testSlug); err != nil {
+		t.Fatal("test setup failed, document not found prior to cleaning")
+	}
+
+	c.clean()
+
+	if _, err := c.getArticleBySlug(testSlug); err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestStartCleaning(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip()
+	}
+
+	oneNanoSecond := int64(1)
+	c := newTestCache(oneNanoSecond)
+
+	if _, err := c.getArticleBySlug(testSlug); err != nil {
+		t.Fatal("test setup failed, document not found prior to cleaning")
+	}
+
+	c.cleanInterval = 100 * time.Millisecond
+	go c.startCleaning()
+	time.Sleep(300 * time.Millisecond)
+
+	if _, err := c.getArticleBySlug(testSlug); err != ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func newTestCache(ttl int64) *cache {
+	return &cache{
+		ttl: ttl,
+		articles: map[string]cacheArticle{
+			testSlug: cacheArticle{
+				article:    domain.Article{Title: "Coltrane"},
+				expiration: time.Now().UnixNano() + ttl,
+			},
+		},
+	}
+}

--- a/repository/errors.go
+++ b/repository/errors.go
@@ -1,0 +1,8 @@
+package repository
+
+import (
+	"errors"
+)
+
+// ErrNotFound indicates that the requested item was not found
+var ErrNotFound = errors.New("requested item not found")

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -14,7 +14,7 @@ type Repository struct {
 }
 
 // New opens a database connection and returns a repository
-func New(uri string) (*Repository, error) {
+func New(uri string, cacheTTL int) (*Repository, error) {
 	fmt.Println("initializing database connection")
 	var (
 		db  *sql.DB
@@ -24,11 +24,11 @@ func New(uri string) (*Repository, error) {
 		return nil, fmt.Errorf("unable to establish connection: %v", err)
 	}
 	if err := db.Ping(); err != nil {
-		return nil, fmt.Errorf("could not ping databasego get github.com/lib/pq, %v", err)
+		return nil, fmt.Errorf("could not ping database, %v", err)
 	}
 	repo := Repository{
 		db:       db,
-		Articles: Articles{db},
+		Articles: Articles{db, newCache(cacheTTL)},
 	}
 	return &repo, nil
 }


### PR DESCRIPTION
This PR adds a cache layer to the articles repository. This is overkill for an already-fast site that receives no traffic, and is done in the spirit of demonstrating how caching can be applied to the repository pattern.